### PR TITLE
Add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   ],
   "author": "Eduardo",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/edu8591/ts-countries-list.git"
+  },
   "type": "commonjs",
   "devDependencies": {
     "@types/node": "^24.6.1",


### PR DESCRIPTION
This pull request makes a small update to the `package.json` file by adding the repository information for the project. This helps users and tooling easily locate the source code.

* Added a `repository` field specifying the project type and URL in `package.json`.